### PR TITLE
BE bug fix

### DIFF
--- a/development/application/config/constants.php
+++ b/development/application/config/constants.php
@@ -95,4 +95,4 @@ defined('ZERO_VALUE') OR define('ZERO_VALUE', 0);
 defined('FIRST_INDEX') OR define('FIRST_INDEX', 0);
 defined('YES') OR define('YES', 1);
 defined('NO') OR define('NO', 0);
-defined('MAX_FIZE_SIZE') OR define('MAX_FILE_SIZE', 25000000);
+defined('MAX_FIZE_SIZE') OR define('MAX_FILE_SIZE', 26214400);

--- a/development/application/models/File.php
+++ b/development/application/models/File.php
@@ -8,8 +8,8 @@
         # Triggered by: (POST) files/upload
         # Requires: $params {"files", "section_id"}
         # Returns: { status: true/false, result: { html, files_uploaded }, error: null }
-        # Last updated at: March 28, 2023
-        # Owner: Jovic
+        # Last updated at: April 20, 2023
+        # Owner: Jovic, Updated by: Jovic
         public function uploadFile($params){
             $response_data = array("status" => false, "result" => array(), "error" => null);
 
@@ -43,7 +43,7 @@
                         $response_data["result"]["file"] = $params["files"]["name"][$index];
                         $response_data["result"]["size"] = $params["files"]["size"][$index];
 
-                        $response_data["error"] = "File size is too large." ;
+                        throw new Exception("File size is too large.");
                     }
                 }
 

--- a/development/assets/js/custom/module_upload_files/module_upload_files_be.js
+++ b/development/assets/js/custom/module_upload_files/module_upload_files_be.js
@@ -56,6 +56,9 @@ function onUploadFiles(event){
             files_counter_text.text(`(${files_counter})`);
             files_counter_text.self().hidden = false;
         }
+        else{
+            alert(response_data.error);
+        }
     }, "json");
     return false;
 }


### PR DESCRIPTION
- Update `MAX_FILE_SIZE` value
- Fix issue where `uploadFIle()` returns `{ status: true }` even if there's an error in uploading a file